### PR TITLE
Add InitContainers to setup config

### DIFF
--- a/folding-cpu.yaml
+++ b/folding-cpu.yaml
@@ -11,7 +11,7 @@ kind: Deployment
 metadata:
   name: fah-cpu
   labels:
-    app: fah-cpu  
+    app: fah-cpu
 spec:
   selector:
     matchLabels:
@@ -25,68 +25,83 @@ spec:
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - fah-cpu
-            topologyKey: "kubernetes.io/hostname"
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - fah-cpu
+              topologyKey: "kubernetes.io/hostname"
       containers:
-      - name: fah-cpu
-        image: "richstokes20/fah-covid:latest"
-        imagePullPolicy: Always
-        resources:
-          limits:
-            cpu: 1000m # How much CPU you wish to donate per node
-            memory: 2Gi
-          requests:
-            cpu: 100m
-            memory: 256Mi
-      #   volumeMounts: # Mount config.xml file
-      #   - name: fah-cpu-config
-      #     mountPath: /etc/fah-cpuclient/config.xml
-      #     subPath: config.xml            
-      # volumes:
-      #   - name: fah-cpu-config
-      #     configMap:
-      #       name: foldingathome-config
+        - name: fah-cpu
+          image: "richstokes20/fah-covid:latest"
+          imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: 1000m # How much CPU you wish to donate per node
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+#           volumeMounts: # Mount config.xml file
+#             - name: data
+#               mountPath: /etc/fahclient
+#       initContainers:
+#         - name: copy-ro-scripts
+#           image: busybox
+#           command:
+#             [
+#               "sh",
+#               "-c",
+#               "cp /etc/fahclient-config/config.xml /etc/fahclient/config.xml",
+#             ]
+#           volumeMounts:
+#             - name: fah-cpu-config
+#               mountPath: /etc/fahclient-config
+#             - name: data
+#               mountPath: /etc/fahclient
+#       volumes:
+#         - name: data
+#           emptyDir: {}
+#         - name: fah-cpu-config
+#           configMap:
+#             name: foldingathome-config
       # priorityClassName: low-priority-class
-# ---
-# apiVersion: v1
-# kind: ConfigMap
-# metadata:
-#   name: foldingathome-config
-# data:
-#   config.xml: |
-#     <config>
-#       <!--
-#         To set your user name, team and passkey just edit the text
-#         in quotes below.
-#       -->
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: foldingathome-config
+data:
+  config.xml: |
+    <config>
+      <!--
+        To set your user name, team and passkey just edit the text
+        in quotes below.
+      -->
 
-#       <!-- User Information -->
-#       <user value=""/> <!-- Enter your user name here -->
-#       <team value=""/>         <!-- Your team number -->
-#       <passkey value=""/>       <!-- 32 hexadecimal characters if provided -->
+      <!-- User Information -->
+      <user value=""/> <!-- Enter your user name here -->
+      <team value=""/>         <!-- Your team number -->
+      <passkey value=""/>       <!-- 32 hexadecimal characters if provided -->
 
-#       <power value="full"/>     <!-- Throttling this at K8s level -->
-#       <gpu value="true"/>      <!-- If true, attempt to autoconfigure GPUs -->
-#       <fold-anon value="true"/>
+      <power value="full"/>     <!-- Throttling this at K8s level -->
+      <gpu value="false"/>      <!-- If true, attempt to autoconfigure GPUs -->
+      <fold-anon value="true"/>
 
-#       <!-- Folding Slots
-#         No folding slot configuration is necessary.  The client will
-#         automaticlaly choose a good configuration for you.  However, here
-#         are some examples:
+      <!-- Folding Slots
+        No folding slot configuration is necessary.  The client will
+        automaticlaly choose a good configuration for you.  However, here
+        are some examples:
       
-#           <slot id="0" type="CPU"/>
+          <slot id="0" type="CPU"/>
 
-#         or
+        or
         
-#           <slot id="0" type="CPU"/>
-#           <slot id="1" type="GPU"/>
+          <slot id="0" type="CPU"/>
+          <slot id="1" type="GPU"/>
 
-#         All slots in a configuration MUST have unique ids.
-#       -->
-#     </config>
-# ---
+        All slots in a configuration MUST have unique ids.
+      -->
+    </config>
+---


### PR DESCRIPTION
Using InitContainers to copy the config from the ConfigMap to `/etc/fahclient`. Mounting at `/etc/fah-cpuclient` doesn't work because the client doesn't read from there. Mounting the configmap directly at `/etc/fahclient` doesn't work because ConfigMap volume mounts are read only. This method copies the file to `/etc/fahclient` so that it has r/w permissions.