### PR TITLE
Update comment about using configmap.

### DIFF
--- a/folding-cpu.yaml
+++ b/folding-cpu.yaml
@@ -84,8 +84,10 @@ spec:
             - "sh"
             - "-c"
             - "cp /etc/fahclient/config.xml /var/lib/fahclient/config.xml"
-            # Use this cp command instead if using ConfigMap config.xml
-            # - "cp /etc/fahclient-config/config.xml /var/lib/fahclient/config.xml"
+            # Use following lines if using ConfigMap config.xml
+            # - "cp"
+            # - "/etc/fahclient-config/config.xml"
+            # - "/var/lib/fahclient/config.xml"
           securityContext:
             runAsNonRoot: true
             runAsUser: 1234

--- a/folding-daemonset.yaml
+++ b/folding-daemonset.yaml
@@ -74,8 +74,10 @@ spec:
             - "sh"
             - "-c"
             - "cp /etc/fahclient/config.xml /var/lib/fahclient/config.xml"
-            # Use this cp command instead if using ConfigMap config.xml
-            # - "cp /etc/fahclient-config/config.xml /var/lib/fahclient/config.xml"
+            # Use following lines if using ConfigMap config.xml
+            # - "cp"
+            # - "/etc/fahclient-config/config.xml"
+            # - "/var/lib/fahclient/config.xml"
           securityContext:
             runAsNonRoot: true
             runAsUser: 1234

--- a/folding-gpu-cpu.yaml
+++ b/folding-gpu-cpu.yaml
@@ -86,8 +86,10 @@ spec:
             - "sh"
             - "-c"
             - "cp /etc/fahclient/config.xml /var/lib/fahclient/config.xml"
-            # Use this cp command instead if using ConfigMap config.xml
-            # - "cp /etc/fahclient-config/config.xml /var/lib/fahclient/config.xml"
+            # Use following lines if using ConfigMap config.xml
+            # - "cp"
+            # - "/etc/fahclient-config/config.xml"
+            # - "/var/lib/fahclient/config.xml"
           securityContext:
             runAsNonRoot: true
             runAsUser: 1234

--- a/folding-gpu.yaml
+++ b/folding-gpu.yaml
@@ -83,8 +83,10 @@ spec:
             - "sh"
             - "-c"
             - "cp /etc/fahclient/config.xml /var/lib/fahclient/config.xml"
-            # Use this cp command instead if using ConfigMap config.xml
-            # - "cp /etc/fahclient-config/config.xml /var/lib/fahclient/config.xml"
+            # Use following lines if using ConfigMap config.xml
+            # - "cp"
+            # - "/etc/fahclient-config/config.xml"
+            # - "/var/lib/fahclient/config.xml"
           securityContext:
             runAsNonRoot: true
             runAsUser: 1234


### PR DESCRIPTION
The init container had a wrong command set to copy the configmap. One line argument does not work.