### PR TITLE
Remove specific UID for OpenShift compatibility

### DIFF
--- a/folding-cpu.yaml
+++ b/folding-cpu.yaml
@@ -61,7 +61,6 @@ spec:
           # Make the container harder to break out of or exploit
           securityContext:
             runAsNonRoot: true
-            runAsUser: 1234
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
           volumeMounts:
@@ -90,7 +89,6 @@ spec:
             # - "/var/lib/fahclient/config.xml"
           securityContext:
             runAsNonRoot: true
-            runAsUser: 1234
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
           volumeMounts:


### PR DESCRIPTION
Attempts to specify UID will fail deployment if fall out of range. https://cloud.redhat.com/blog/a-guide-to-openshift-and-uids

Tested and worked as is, so left the command as is.
```
            - "--run-as"
            - "1234"
```