### PR TITLE
Upgrade to ARM64 compatible cuda base image. Add actions for publishing multi-arch images.

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,105 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  schedule:
+    - cron: '29 3 * * *'
+  push:
+    branches: [ "master" ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: linux/arm64,linux/amd64
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
+        with:
+          cosign-release: 'v1.11.0'
+
+      - uses: satackey/action-docker-layer-caching@v0.0.11
+      # Ignore the failure of a step and avoid terminating the job.
+        continue-on-error: true
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}

--- a/folding-cpu.yaml
+++ b/folding-cpu.yaml
@@ -40,7 +40,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       containers:
         - name: fah-cpu
-          image: "richstokes20/fah-covid:latest"
+          image: "ghcr.io/richstokes/k8s-fah:master"
           # --run-as UID should match runAsUser value in containers securityContext
           command:
             - "/usr/bin/FAHClient"

--- a/folding-daemonset.yaml
+++ b/folding-daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       #   effect: NoSchedule
       containers:
         - name: fah-cpu
-          image: "richstokes20/fah-covid:latest"
+          image: "ghcr.io/richstokes/k8s-fah:master"
           # --run-as UID should match runAsUser value in containers securityContext
           command:
             - "/usr/bin/FAHClient"

--- a/folding-gpu-cpu.yaml
+++ b/folding-gpu-cpu.yaml
@@ -40,7 +40,7 @@ spec:
 
       containers:
         - name: fah-gpu-cpu
-          image: "richstokes20/fah-covid:latest"
+          image: "ghcr.io/richstokes/k8s-fah:master"
           # --run-as UID should match runAsUser value in containers securityContext
           command:
             - "/usr/bin/FAHClient"

--- a/folding-gpu.yaml
+++ b/folding-gpu.yaml
@@ -40,7 +40,7 @@ spec:
 
       containers:
         - name: fah-gpu
-          image: "richstokes20/fah-covid:latest"
+          image: "ghcr.io/richstokes/k8s-fah:master"
           # --run-as UID should match runAsUser value in containers securityContext
           command:
             - "/usr/bin/FAHClient"

--- a/folding-minikube.yaml
+++ b/folding-minikube.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: fah-cpu
-          image: "richstokes20/fah-covid:latest"
+          image: "ghcr.io/richstokes/k8s-fah:master"
           # --run-as UID should match runAsUser value in containers securityContext
           command:
             - "/usr/bin/FAHClient"


### PR DESCRIPTION
When merged, if repo has github actions enabled, you will see packages published after each commit to master like here
https://github.com/kaovilai?tab=packages&repo_name=k8s-fah

This action is used to build and push multi-arch linux/arm64 and linux/amd64 image in a single tag automatically.
Works for any forks and in this upstream.
Uses GitHub Container Registry by default so it works for all GitHub forks and upstream without additional secret/env setup.

This requires no additional configuration from repository owner or future forkers.

Closes https://github.com/richstokes/k8s-fah/issues/14

Nvidia publish base cuda Docker images for arm64 starting with `nvidia/cuda:11.0.3-runtime-ubuntu18.04` so I had to upgrade that image.